### PR TITLE
docs(architecture): fix stale §3/§4 launch flow (WINELOADER, prefix-cx) to match shipped launcher.sh

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,11 +61,11 @@ osxEQL/
 ├── Wine/                     # the Wine runtime (bin/, lib/wine/{x86_64,i386}-{windows,unix})
 │                             # currently a COPY of CrossOver's LGPL Wine build (has macdrv_functions)
 │                             # + DXMT v0.80 installed into its lib/wine tree
-├── prefix/                   # a wineprefix that physically holds the 6.7 GB EQ client
+├── prefix/                   # THE ACTIVE PREFIX — a win64 wineprefix that physically holds the
+│                             #   6.7 GB EQ client; system32/winemetal.dll present; Fullscreen=0
 │                             #   drive_c/users/Public/Daybreak Game Company/Installed Games/EverQuest Legends/
-├── prefix-cx/                # THE ACTIVE PREFIX (created by CrossOver's wineloader)
-│                             #   its EQ folder is a SYMLINK into prefix/ (so the 6.7 GB isn't duplicated)
-│                             #   system32/winemetal.dll present; Fullscreen=0 windowed config
+├── prefix-cx/                # legacy back-compat fallback ONLY (older extracted-from-CrossOver
+│                             #   installs). launcher.sh uses it only if prefix/ has no system.reg.
 ├── backends/dxmt-v0.80/      # extracted DXMT release (the open-source backend DLLs + winemetal.so)
 ├── cache/                    # downloaded Wine/DXMT tarballs
 ├── build/                    # vanilla-Wine build workspace (engine/build-wine.sh)
@@ -79,15 +79,20 @@ CrossOver.app installed or the original bottles — verified the Wine runs stand
 
 ## 4. The launch flow
 
-The app (`~/Desktop/osxEQL.app/Contents/MacOS/osxEQL`) does:
+The app (`/Applications/osxEQL.app/Contents/MacOS/osxEQL`) does, in essence:
 
 ```bash
-export WINEPREFIX=~/Library/Application Support/osxEQL/prefix-cx
-export WINELOADER=$WINE_DIR/bin/wineloader
+WINE=$WINE_DIR/bin/wine                 # bin/wine is the real Mach-O loader — drive it directly
+export WINEPREFIX="$HOME/Library/Application Support/osxEQL/prefix"
 export WINESERVER=$WINE_DIR/bin/wineserver
 export WINEDLLPATH=$WINE_DIR/lib/wine/x86_64-windows:$WINE_DIR/lib/wine/i386-windows
+export WINEDEBUG=-all
+export WINEDLLOVERRIDES='mscoree,mshtml='
+# Do NOT export WINELOADER: with a from-source bin/wine it makes wine copy the loader
+# to a temp dir for child processes (explorer→LaunchPad→eqgame), which then fail
+# 'could not load ntdll.so'. See gotcha #2 in CLAUDE.md / STATUS.md.
 caffeinate -dimsu -w $$ &
-exec "$WINELOADER" explorer /desktop=osxEQL,1280x960 'C:\...\LaunchPad.exe'
+exec "$WINE" explorer /desktop=osxEQL,1280x960 'C:\...\LaunchPad.exe'
 ```
 
 - `explorer /desktop=NAME,WxH` runs everything inside a Wine **virtual desktop** — this


### PR DESCRIPTION
## What

`docs/ARCHITECTURE.md` §4 ("The launch flow") and part of §3 ("The runtime layout") describe the **older extracted-from-CrossOver** build and contradict the **shipped `app/launcher.sh` (v0.2.0)** — and, more importantly, the project's own **gotcha #2** in `STATUS.md` / `CLAUDE.md` ("**do NOT set `WINELOADER`**").

## Why it matters

§4 currently instructs:

```bash
export WINEPREFIX=~/Library/Application Support/osxEQL/prefix-cx
export WINELOADER=$WINE_DIR/bin/wineloader
...
exec "$WINELOADER" explorer ...
```

With the shipped **from-source `bin/wine`** (a real Mach-O loader), exporting `WINELOADER` makes wine copy the loader into a temp dir for child processes (`explorer → LaunchPad → eqgame`), which then die with `could not load ntdll.so` — exactly the failure mode `STATUS.md` / `CLAUDE.md` warn against. Anyone following ARCHITECTURE.md to script or debug a launch hits it.

Two smaller drifts fixed alongside:

- §3 calls `prefix-cx/` "**THE ACTIVE PREFIX**". A fresh v0.2.0 install uses `prefix/`; `prefix-cx/` is only a back-compat fallback (`launcher.sh` uses it solely when `prefix/` has no `system.reg`).
- App path `~/Desktop/osxEQL.app` → `/Applications/osxEQL.app`, and added the `WINEDEBUG` / `WINEDLLOVERRIDES` the app actually exports.

The updated §4 now mirrors `app/launcher.sh` exactly.

## Verification (macOS 26.4, Apple Silicon, fresh v0.2.0 install)

```
$ file .../osxEQL.app/Contents/Resources/Wine/bin/wine
Mach-O 64-bit executable x86_64          # real loader, not a Perl wrapper
$ ls -l .../Wine/bin/wineloader
wineloader -> wine                        # just a symlink to it
$ ls "~/Library/Application Support/osxEQL/"
logs/    prefix/                          # prefix/ exists; NO prefix-cx
```

`app/launcher.sh` drives `"$WINE"` (= `bin/wine`) directly and comments *"NEVER export WINELOADER"*, consistent with this change.

## Left out of this PR (possible follow-up)

§3's prose ("runs standalone via `wineloader` … CrossOver's `bin/wine` Perl wrapper") and the §7 "Currently CrossOver's LGPL build" row also describe the earlier extracted build rather than the shipped from-source one. I kept this PR tightly scoped to the actively-misleading launch snippet + prefix claim — happy to fold those in if you'd like.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
