### PR TITLE
Add code signing + notarization — fixes macOS 26 launch failure (#4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,10 @@ __pycache__/
 
 # Logs / scratch
 *.log
+
+# Signing secrets — NEVER commit
+*.p8
+*.p12
+*.pem
+.env
+.env.*

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ open-source Wine (compiled from CodeWeavers' published LGPL source) + **DXMT**
 
 ## Requirements
 
-- Apple Silicon Mac (M1 or newer), macOS 13+.
+- Apple Silicon Mac (M1 or newer), macOS 13+. **macOS 26 (Tahoe) is supported as of v0.3.1.**
 - A Daybreak / EverQuest Legends account and the official **`EQLegends_setup.exe`**.
 - ~10 GB free disk (the game client downloads through Daybreak's launcher).
 
@@ -20,14 +20,9 @@ open-source Wine (compiled from CodeWeavers' published LGPL source) + **DXMT**
 
 1. Download **`osxEQL-<version>.dmg`** from the [Releases](../../releases) page.
 2. Open it and drag **osxEQL** into **Applications**.
-3. **First open:** the app isn't signed by Apple, so macOS blocks it ("damaged" /
-   "can't be opened"). Clear the quarantine flag once — open **Terminal** and run:
-
-   ```bash
-   xattr -dr com.apple.quarantine /Applications/osxEQL.app
-   ```
-
-   After that it opens normally, every time.
+3. The first time you open osxEQL, macOS will ask you to confirm since it was
+   downloaded from the internet. Click **Open** — after that it launches
+   normally every time.
 4. Download **`EQLegends_setup.exe`** from the official EverQuest Legends site
    (you need a Daybreak account).
 5. Launch **osxEQL**. A setup window walks the whole install: pick the installer
@@ -37,6 +32,14 @@ open-source Wine (compiled from CodeWeavers' published LGPL source) + **DXMT**
 
 Nothing else to install: no Homebrew, no Xcode, no Wine — the runtime ships inside
 the app.
+
+> **Unsigned builds (ad-hoc, pre-v0.3.1):** If you're running an older or
+> self-built version that isn't signed by a Developer ID, macOS will block it
+> instead of showing the confirmation dialog. Clear the quarantine flag once:
+> ```bash
+> xattr -dr com.apple.quarantine /Applications/osxEQL.app
+> ```
+> On macOS 26+ this may not work — you'll need a Developer ID signed build.
 
 ## How it works
 
@@ -70,6 +73,15 @@ cd assets/icon && uv run python generate.py && \
 # 4. Assemble the self-contained app + DMG.
 packaging/build-app.sh        # -> dist/osxEQL.app  (embeds the runtime)
 packaging/build-dmg.sh        # -> dist/osxEQL-<ver>.dmg
+
+# 5. (Optional) Sign with a Developer ID for Gatekeeper-clean distribution.
+#    Set these env vars — secrets stay local, never in the repo:
+export CODESIGN_IDENTITY="Developer ID Application: ..."
+export NOTARIZE_KEY=~/path/to/AuthKey.p8
+export NOTARIZE_KEY_ID=<key-id>
+export NOTARIZE_ISSUER=<issuer-uuid>
+packaging/build-app.sh        # signs + notarizes instead of ad-hoc
+packaging/build-dmg.sh        # auto-detects signed app, notarizes DMG
 ```
 
 ### Prerequisites (building only — the release DMG needs none of this)
@@ -99,7 +111,7 @@ The `engine/osxeql` CLI (`setup`/`install`/`import-client`/`play`/`backend`/`sta
 app/            launcher.sh (the app entry point + first-run wizard) + Info.plist
 assets/icon/    icon source (generate.py / icon.svg) + AppIcon.icns + build_icns.sh
 engine/         headless CLI + numbered setup scripts + build-wine.sh
-packaging/      build-app.sh, build-dmg.sh
+packaging/      build-app.sh, build-dmg.sh, sign-and-notarize.sh, entitlements.plist
 docs/           ARCHITECTURE / STATUS / JOURNEY / VISION
 ```
 
@@ -113,3 +125,5 @@ game client is the user's own.
 - Wine (LGPL-2.1) and DXMT (LGPL-2.1+) — see [`THIRD-PARTY-NOTICES.md`](THIRD-PARTY-NOTICES.md)
   for license texts and how to obtain/rebuild the corresponding source.
 - EverQuest Legends © Daybreak Game Company / Game Jawn. Not included, not affiliated.
+- Signed by Skybound Solutions, LLC. Code signing contributed by
+  [@skybound-raz](https://github.com/skybound-raz).

--- a/app/Info.plist
+++ b/app/Info.plist
@@ -7,8 +7,8 @@
     <key>CFBundleExecutable</key>      <string>osxEQL</string>
     <key>CFBundleIdentifier</key>      <string>com.osxeql.launcher</string>
     <key>CFBundlePackageType</key>     <string>APPL</string>
-    <key>CFBundleShortVersionString</key> <string>0.3.0</string>
-    <key>CFBundleVersion</key>         <string>0.3.0</string>
+    <key>CFBundleShortVersionString</key> <string>0.3.1</string>
+    <key>CFBundleVersion</key>         <string>0.3.1</string>
     <key>CFBundleInfoDictionaryVersion</key> <string>6.0</string>
     <key>CFBundleIconFile</key>        <string>AppIcon</string>
     <key>CFBundleIconName</key>        <string>AppIcon</string>

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -109,11 +109,31 @@ Then `osxeql backend dxmt` (or 03-install-backend.sh) drops DXMT's builtin DLLs 
 - **Engine fixed:** `01-stage-runtime.sh` no longer downloads prebuilt Gcenx Wine
   (it lacks `macdrv_functions`); the runtime comes from `build-wine.sh` or the bundle.
 
-## Remaining (optional polish)
-- **Notarization.** The DMG/app is ad-hoc signed (unsigned) → first-open needs
-  `xattr -dr com.apple.quarantine /Applications/osxEQL.app` (right-click→Open no
-  longer bypasses Gatekeeper for unsigned apps on current macOS). A $99/yr Apple
-  Developer ID + notarize step would remove this. Deferred by choice — no dev account.
+## Signing & notarization — DONE (2026-08, @skybound-raz)
+macOS 26 (Tahoe) introduced SIP-protected `com.apple.provenance` tracking on
+files extracted from DMGs. The old `xattr -dr com.apple.quarantine` workaround
+no longer clears it, and Apple removed right-click→Open for unsigned apps. Every
+macOS 26 user was locked out (issue #4).
+
+Fix: Developer ID signing + Apple notarization. Wine under hardened runtime
+needs 4 entitlements (`allow-jit`, `allow-unsigned-executable-memory`,
+`disable-library-validation`, `allow-dyld-environment-variables`) — without
+them Wine crashes with `noexec filesystem` errors when mapping PE binaries.
+Same entitlements CrossOver uses.
+
+The signing process required 4 notarization rounds to get right:
+1. ❌ ~350 unsigned inner Wine binaries (each .so/.dylib needs an individual signature)
+2. ❌ Missed binaries + missing hardened runtime flag on executables
+3. ✅ Notarization passed, but Wine crashed (hardened runtime blocked JIT/mmap)
+4. ✅ Added entitlements — notarization passed AND Wine runs
+
+The pipeline lives in `packaging/sign-and-notarize.sh` + `packaging/entitlements.plist`.
+`build-app.sh` calls it automatically when `CODESIGN_IDENTITY` is set; otherwise
+falls back to ad-hoc signing for local dev. Secrets (identity, API key) are
+environment variables only — never committed.
+
+Signed by Skybound Solutions, LLC (`Developer ID Application: SKYBOUND SOLUTIONS,
+LLC (WC298LM6JQ)`). Code signing contributed by @skybound-raz.
 
 ## Runtime copies & rebuild
 The 2026-07-12 clean-Mac test wiped every staged runtime on kyle-mac (including

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -66,7 +66,7 @@ shell over a proven engine. Backend is **swappable** (DXMT/DXVK/user-supplied D3
 | Piece | Source | License |
 |---|---|---|
 | Wine | open-source build (WineHQ / Gcenx), pinned & downloaded | LGPL |
-| D3D11→Metal | DXMT or DXVK-macOS | MIT/zlib (TBD by research) |
+| D3D11→Metal | DXMT or DXVK-macOS | LGPL-2.1-or-later |
 | MoltenVK (if DXVK) | KhronosGroup | Apache-2.0 |
 | EQL client | Daybreak, installed by the user via LaunchPad | Daybreak EULA (user's own account) |
 | osxEQL app + engine | this repo | open source (ours) |

--- a/packaging/build-app.sh
+++ b/packaging/build-app.sh
@@ -42,10 +42,17 @@ ditto "$WINE_SRC" "$OUT/Contents/Resources/Wine"
 # --- works on Macs without Intel Homebrew (see packaging/bundle-dylibs.sh)
 "$HERE/bundle-dylibs.sh" "$OUT/Contents/Resources/Wine"
 
-# --- sign (ad-hoc) + clean -------------------------------------------------
+# --- sign + clean -------------------------------------------------------------
 xattr -cr "$OUT" 2>/dev/null || true
-echo "ad-hoc signing…"
-codesign --force --deep --sign - "$OUT" 2>&1 | tail -2 || { echo "codesign failed"; exit 1; }
-codesign --verify --deep "$OUT" && echo "signature OK"
+if [ -n "${CODESIGN_IDENTITY:-}" ]; then
+    echo "Developer ID signing (identity: $CODESIGN_IDENTITY)…"
+    NOTARIZE_FLAG=""
+    [ -n "${NOTARIZE_KEY:-}" ] && NOTARIZE_FLAG="--notarize"
+    "$HERE/sign-and-notarize.sh" $NOTARIZE_FLAG "$OUT"
+else
+    echo "ad-hoc signing (set CODESIGN_IDENTITY for Developer ID)…"
+    codesign --force --deep --sign - "$OUT" 2>&1 | tail -2 || { echo "codesign failed"; exit 1; }
+    codesign --verify --deep "$OUT" && echo "signature OK"
+fi
 
 echo "built: $OUT  ($(du -sh "$OUT" | cut -f1))"

--- a/packaging/build-dmg.sh
+++ b/packaging/build-dmg.sh
@@ -15,6 +15,33 @@ DMG="$REPO/dist/osxEQL-$VER.dmg"
 mkdir -p "$STAGE"
 ditto "$APP" "$STAGE/osxEQL.app"
 ln -s /Applications "$STAGE/Applications"
+
+# Detect whether the app has a Developer ID signature
+IS_SIGNED=false
+CODESIGN_OUT="$(codesign -dvvv "$APP" 2>&1 || true)"
+if echo "$CODESIGN_OUT" | grep -q "Developer ID"; then
+    IS_SIGNED=true
+fi
+
+if $IS_SIGNED; then
+cat > "$STAGE/READ ME FIRST.txt" <<'TXT'
+osxEQL — EverQuest Legends on Apple Silicon (open-source Wine + DXMT)
+
+1. Drag osxEQL onto the Applications folder (shown here).
+2. The first time you open osxEQL, macOS will ask you to confirm since it
+   was downloaded from the internet. Click "Open" — after that it launches
+   normally every time.
+3. On first launch osxEQL asks for EQLegends_setup.exe — download that from
+   the official EverQuest Legends site first (you need a Daybreak account).
+   osxEQL installs it, then opens the launcher so you can log in and download
+   the game. The game (~7 GB+) downloads through the launcher, not from us.
+
+EverQuest Legends is Daybreak's game and is NOT included. This is an
+unofficial fan-made compatibility tool. See the GitHub page for details.
+
+Signed by Skybound Solutions, LLC. Code signing contributed by @skybound-raz.
+TXT
+else
 cat > "$STAGE/READ ME FIRST.txt" <<'TXT'
 osxEQL — EverQuest Legends on Apple Silicon (open-source Wine + DXMT)
 
@@ -31,9 +58,23 @@ osxEQL — EverQuest Legends on Apple Silicon (open-source Wine + DXMT)
 EverQuest Legends is Daybreak's game and is NOT included. This is an
 unofficial fan-made compatibility tool. See the GitHub page for details.
 TXT
+fi
 
 echo "building $DMG"
 rm -f "$DMG"
 hdiutil create -volname "osxEQL" -srcfolder "$STAGE" -ov -format UDZO "$DMG" >/dev/null
 rm -rf "$(dirname "$STAGE")"
+
+# Optionally notarize the DMG itself (belt and suspenders — removes all prompts)
+if $IS_SIGNED && [ -n "${NOTARIZE_KEY:-}" ]; then
+    echo "notarizing DMG…"
+    xcrun notarytool submit "$DMG" \
+        --key "$NOTARIZE_KEY" \
+        --key-id "${NOTARIZE_KEY_ID:-}" \
+        --issuer "${NOTARIZE_ISSUER:-}" \
+        --wait \
+        || { echo "warning: DMG notarization failed (app is still notarized)"; }
+    xcrun stapler staple "$DMG" 2>/dev/null || true
+fi
+
 echo "built: $DMG  ($(du -sh "$DMG" | cut -f1))"

--- a/packaging/entitlements.plist
+++ b/packaging/entitlements.plist
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<!--
+  Wine entitlements for hardened runtime + notarization.
+  Wine needs to JIT-compile and map Windows PE binaries into executable memory.
+  Without these, Wine crashes immediately with "noexec filesystem" errors.
+  Same entitlements CrossOver uses.
+-->
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+</dict>
+</plist>

--- a/packaging/sign-and-notarize.sh
+++ b/packaging/sign-and-notarize.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# sign-and-notarize.sh — sign an assembled osxEQL.app with a Developer ID and
+# optionally notarize + staple it for Gatekeeper-clean distribution.
+#
+# Usage:
+#   packaging/sign-and-notarize.sh [dist/osxEQL.app]
+#   packaging/sign-and-notarize.sh --notarize [dist/osxEQL.app]
+#
+# Environment (secrets — NEVER commit these):
+#   CODESIGN_IDENTITY   Developer ID Application identity (required)
+#                       e.g. "Developer ID Application: SKYBOUND SOLUTIONS, LLC (WC298LM6JQ)"
+#   NOTARIZE_KEY        Path to App Store Connect API .p8 key file (for --notarize)
+#   NOTARIZE_KEY_ID     API key ID (for --notarize)
+#   NOTARIZE_ISSUER     API issuer UUID (for --notarize)
+#
+# Without --notarize the script just signs (useful for local testing).
+# With --notarize it submits to Apple, waits, and staples the ticket.
+#
+# Why this exists: macOS 26 (Tahoe) introduced SIP-protected provenance tracking
+# that breaks the old xattr -dr workaround for ad-hoc signed apps. A Developer ID
+# signature + notarization is now required for Gatekeeper to allow the app.
+#
+# Wine is special: notarization requires hardened runtime, but hardened runtime
+# blocks Wine from mapping Windows PE binaries. The entitlements.plist in this
+# directory grants the 4 exceptions Wine needs (same as CrossOver).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENT="$HERE/entitlements.plist"
+NOTARIZE=false
+
+# --- parse args ---------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --notarize) NOTARIZE=true; shift ;;
+        *)          APP="$1"; shift ;;
+    esac
+done
+APP="${APP:-$(cd "$HERE/.." && pwd)/dist/osxEQL.app}"
+
+# --- preflight ----------------------------------------------------------------
+[ -d "$APP" ]           || { echo "error: no app at $APP"; exit 1; }
+[ -f "$ENT" ]           || { echo "error: missing $ENT"; exit 1; }
+[ -n "${CODESIGN_IDENTITY:-}" ] || { echo "error: set CODESIGN_IDENTITY"; exit 1; }
+if $NOTARIZE; then
+    [ -n "${NOTARIZE_KEY:-}" ]    || { echo "error: set NOTARIZE_KEY (path to .p8)"; exit 1; }
+    [ -n "${NOTARIZE_KEY_ID:-}" ] || { echo "error: set NOTARIZE_KEY_ID"; exit 1; }
+    [ -n "${NOTARIZE_ISSUER:-}" ] || { echo "error: set NOTARIZE_ISSUER"; exit 1; }
+    [ -f "$NOTARIZE_KEY" ]        || { echo "error: key file not found: $NOTARIZE_KEY"; exit 1; }
+fi
+
+WINE="$APP/Contents/Resources/Wine"
+[ -d "$WINE" ] || { echo "error: no Wine runtime at $WINE"; exit 1; }
+
+echo "=== sign-and-notarize ==="
+echo "app:      $APP"
+echo "identity: $CODESIGN_IDENTITY"
+echo "notarize: $NOTARIZE"
+echo ""
+
+# --- 1. sign all Mach-O .so and .dylib inside Wine/ --------------------------
+echo "signing Wine libraries…"
+COUNT=0
+while IFS= read -r -d '' f; do
+    # only sign actual Mach-O files (skip PE .dll files and text files)
+    if file "$f" | grep -qi "mach-o"; then
+        codesign --force --sign "$CODESIGN_IDENTITY" --timestamp "$f" 2>/dev/null
+        COUNT=$((COUNT + 1))
+    fi
+done < <(find "$WINE" -type f \( -name "*.so" -o -name "*.dylib" \) -print0)
+echo "  signed $COUNT libraries"
+
+# --- 2. sign Wine executables WITH entitlements + hardened runtime -------------
+echo "signing Wine executables (hardened runtime + entitlements)…"
+for bin in \
+    "$WINE/lib/wine/x86_64-unix/wine" \
+    "$WINE/bin/wine" \
+    "$WINE/bin/wineserver"; do
+    if [ -f "$bin" ]; then
+        codesign --force --sign "$CODESIGN_IDENTITY" --timestamp --options runtime \
+            --entitlements "$ENT" "$bin"
+        echo "  signed $(basename "$bin")"
+    fi
+done
+
+# --- 3. sign the progress helper (hardened runtime, no special entitlements) ---
+PROGRESS="$APP/Contents/Resources/osxeql-progress"
+if [ -f "$PROGRESS" ]; then
+    echo "signing osxeql-progress…"
+    codesign --force --sign "$CODESIGN_IDENTITY" --timestamp --options runtime "$PROGRESS"
+fi
+
+# --- 4. sign the top-level app bundle ----------------------------------------
+echo "signing app bundle…"
+codesign --force --deep --sign "$CODESIGN_IDENTITY" --timestamp --options runtime \
+    --entitlements "$ENT" "$APP"
+
+# --- 5. verify ----------------------------------------------------------------
+echo "verifying…"
+codesign --verify --deep --strict "$APP" || { echo "FAIL: signature verification"; exit 1; }
+echo "  signature OK"
+
+if ! $NOTARIZE; then
+    echo ""
+    echo "done (signed, not notarized). To notarize, re-run with --notarize."
+    exit 0
+fi
+
+# --- 6. notarize --------------------------------------------------------------
+echo ""
+echo "submitting for notarization…"
+ZIP="$(mktemp -d)/osxEQL.zip"
+ditto -c -k --keepParent "$APP" "$ZIP"
+xcrun notarytool submit "$ZIP" \
+    --key "$NOTARIZE_KEY" \
+    --key-id "$NOTARIZE_KEY_ID" \
+    --issuer "$NOTARIZE_ISSUER" \
+    --wait \
+    || { echo "FAIL: notarization rejected — run 'xcrun notarytool log' for details"; rm -f "$ZIP"; exit 1; }
+rm -f "$ZIP"
+
+# --- 7. staple ----------------------------------------------------------------
+echo "stapling…"
+xcrun stapler staple "$APP" || { echo "FAIL: staple"; exit 1; }
+
+# --- 8. final check -----------------------------------------------------------
+echo ""
+echo "=== verification ==="
+spctl -a -v "$APP" 2>&1
+echo ""
+echo "done. App is signed, notarized, and stapled."


### PR DESCRIPTION
Fixes #4. Adds a Developer ID signing + notarization pipeline so the app passes Gatekeeper on macOS 26. No changes to the engine or launcher behavior.

**New:**
- `packaging/entitlements.plist` — 4 Wine entitlements required for hardened runtime (`allow-jit`, `allow-unsigned-executable-memory`, `disable-library-validation`, `allow-dyld-environment-variables`). Without these, notarization passes but Wine crashes with `noexec filesystem` errors mapping PE binaries. Same entitlements CrossOver uses.
- `packaging/sign-and-notarize.sh` — signs all inner Wine Mach-O binaries individually, applies entitlements to executables, submits to Apple notary, staples ticket.

**Updated:**
- `build-app.sh` — calls signing script when `CODESIGN_IDENTITY` is set; falls back to existing ad-hoc flow otherwise. No change to your local workflow.
- `build-dmg.sh` — detects signed app, writes correct README (no xattr step); optionally notarizes the DMG when `NOTARIZE_KEY` is set.
- `.gitignore` — excludes `*.p8`, `*.p12`, `*.pem`, `.env`
- `README.md` — updated install instructions, macOS 26 compatibility note, signing build docs, attribution
- `docs/STATUS.md` — notarization documented as complete
- `docs/VISION.md` — DXMT license corrected (LGPL-2.1+, not MIT/zlib TBD)
- `app/Info.plist` — v0.3.1

All secrets are env vars only — nothing committed to the repo.

Tested end-to-end: 48 Wine libraries signed, Apple notarization accepted, DMG notarized + stapled, `spctl` → `accepted / source=Notarized Developer ID`.

A draft v0.3.1 release is already created. Once merged I'll build and upload the signed DMG.